### PR TITLE
change name to fullname, to allow dealing with jobs that has a simila…

### DIFF
--- a/src/main/java/git/bisect/builder/CommitTester.java
+++ b/src/main/java/git/bisect/builder/CommitTester.java
@@ -159,7 +159,7 @@ public class CommitTester {
 		if (jenkins == null) return null;
 		
 		for (Job<?, ?> proj : jenkins.getAllItems(Job.class)) 
-			if (proj.getName().equals(jobToRun))
+			if (proj.getFullName().equals(jobToRun))
 				return proj;
 		return null;
 	}


### PR DESCRIPTION
Hi, 

motivation for this change is to support jobs that has a similar name in different folders
for example you have a "deploy" folder with jobs X,Y and Z and "tests" folder with jobs X,Y and Z
this way you can get be sure which job will be started.

I think this change, will break previous versions as it will require a change in the job format.

last , let me just say I didn't test it - as I know nothing about Jenkins plugins and how to set them up.. I just used the documentation for this change.. 

Thanks