### PR TITLE
[JENKINS-66329] Prepare Git Bisect for core Guava upgrade

### DIFF
--- a/src/main/java/git/bisect/builder/CommandsRunner.java
+++ b/src/main/java/git/bisect/builder/CommandsRunner.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.google.common.io.CharStreams;
-
 import git.bisect.Logger;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -120,9 +118,8 @@ public class CommandsRunner {
 		return null;
 	}
 
-	private List<String> linesOf(String s) throws IOException, InterruptedException {
-		return CharStreams.readLines(
-				CharStreams.newReaderSupplier(s));
+	private static List<String> linesOf(String s) {
+		return Arrays.asList(s.split("\\R"));
 	}
 	
 	public boolean checkExistance(String commit) throws IOException, InterruptedException {


### PR DESCRIPTION
See [JENKINS-66329](https://issues.jenkins.io/browse/JENKINS-66329) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using `com/google/common/io/CharStreams#newReaderSupplier` and `com/google/common/io/CharStreams#readLines`, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/io/CharStreams.html) but were [removed in later versions](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/io/CharStreams.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This PR rewrites this code in favor of native Java Platform functionality. This prepares the plugin to work on both old and new versions of Guava.